### PR TITLE
develop: link to Hosted Weblate instead of the deprecated Launchpad translation page

### DIFF
--- a/develop/index.md
+++ b/develop/index.md
@@ -19,4 +19,4 @@ If you would like to help, here are a few things you can do:
 - **Development**: Can you speak C++? The [XCSoar Developer Manual]({{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/XCSoar-developer-manual.pdf) has instructions on how to get the source code, hack it, and submit your patches.  You can contact other developers here [here](/contact/).
 - **Testing**: Download XCSoar, test it, and [report bugs](/develop/new_ticket.html).
 - **Documentation**: Can you edit in Latex? We need editors for the XCSoar manual. It is outdated, and needs some care. See the final section of the XCSoar Developer Manual mentioned above for instructions on how to edit the manuals.
-- **Translation**: Check our [Launchpad page](https://translations.launchpad.net/xcsoar/trunk) if you want to help.
+- **Translation**: Check our [Hosted Weblate page](https://hosted.weblate.org/projects/xcsoar) if you want to help.


### PR DESCRIPTION
With support from @Turbo87, I had tried to reactivate the Launchpad translation portal. But unfortunately, it cannot import Git repositories with submodules.

So I made a request to get a project account on Hosted Weblate, and here it is:
https://hosted.weblate.org/projects/xcsoar/
It is based on the Weblate Open Source Software.

In the current configuration, it gets its updates automatically from our master repository, and changes on the Weblate side can from the pulled from its Git repository on
https://hosted.weblate.org/git/xcsoar/translations/

Do you think this it is a good solution?