### PR TITLE
WIP: Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+rvm:
+  - 2.4.1
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - yui-compressor
+    - librsvg2-bin
+
+cache: bundler
+
+script: bundle exec jekyll build


### PR DESCRIPTION
Based on #5.

@lordfolken: The deployment script including secrects is missing. The rendered website can be found in `./_site/`.