### PR TITLE
Airspace: France: link update

### DIFF
--- a/download/data.md
+++ b/download/data.md
@@ -33,7 +33,7 @@ XCSoar supports the Tim Newport-Pearce (.sua) and OpenAir (.txt) file formats.
 - [Download Airspace from Soaringweb](http://soaringweb.org/Airspace/)
 - [Austrian Airspace](https://www.austrocontrol.at/en/atm/aim_services/aim_products/airspace_structure)
 - [Dutch Airspace](http://www.gliderpilotshop.nl/winkel/product_info.php?cPath=110_96&products_id=428)
-- [French Airspace](http://www.ffvvespaceaerien.org/?page_id=412)
+- [French Airspace](https://www.ffvp.fr/liens-utiles-telechargements)
 - [German Airspace](http://www.daec.de/fachbereiche/luftraum-flugbetrieb/luftraumdaten/)
 - [US Airspace](http://www.soaringdata.info/)
 


### PR DESCRIPTION
The airspace file maintained by the French soaring association as moved. Link corrected