### PR TITLE
Update of stable version (6.8.13 -> 6.8.14)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 permalink: /discover/:year/:month/:day/:title.html
 
-xcsoar_stable_version: 6.8.13
+xcsoar_stable_version: 6.8.14
 xcsoar_testing_version: null
-xcsoar_old_version: 6.8.11
+xcsoar_old_version: 6.8.13
 
 server_url: ''
 absolute_server_url: '//www.xcsoar.org'


### PR DESCRIPTION
Noticing in issue https://github.com/XCSoar/XCSoar/issues/436 that the website has not been updated after the release of version 6.8.14, here is the change for the website.