### PR TITLE
removed traces of OSX as it isn't supported anymore

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -27,7 +27,6 @@ but is hidden).  Reboot the Kobo.
 - {:.list-item-windows}[XCSoar {{ site.xcsoar_stable_version }} on Windows]({{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/PC/)
 - {:.list-item-windows}[XCSoar {{ site.xcsoar_stable_version }} on Windows (64 bit)]({{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/WIN64/)
 - {:.list-item-linux}[XCSoar {{ site.xcsoar_stable_version }} on Linux]({{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/LINUX/)
-- {:.list-item-mac}[XCSoar {{ site.xcsoar_stable_version }} on macOS]({{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/OSX/)
 
 ## XCSoar {{ site.xcsoar_stable_version }} on single-board computers
 

--- a/download/latest.md
+++ b/download/latest.md
@@ -27,7 +27,6 @@ but is hidden).  Reboot the Kobo.
 - {:.list-item-windows}[XCSoar {{ site.xcsoar_testing_version }} on Windows]({{ site.download_server_url }}/{{ site.xcsoar_testing_version }}/PC/)
 - {:.list-item-windows}[XCSoar {{ site.xcsoar_testing_version }} on Windows (64 bit)]({{ site.download_server_url }}/{{ site.xcsoar_testing_version }}/WIN64/)
 - {:.list-item-linux}[XCSoar {{ site.xcsoar_testing_version }} on Linux]({{ site.download_server_url }}/{{ site.xcsoar_testing_version }}/LINUX/)
-- {:.list-item-mac}[XCSoar {{ site.xcsoar_testing_version }} on macOS]({{ site.download_server_url }}/{{ site.xcsoar_testing_version }}/OSX/)
 
 ## XCSoar {{ site.xcsoar_stable_version }} on single-board computers
 

--- a/hardware/index.md
+++ b/hardware/index.md
@@ -6,7 +6,7 @@ menu: hardware
 ---
 
 XCSoar runs on a wide variety of hardware: all desktop computers
-(Windows, Linux, Mac OS X), Android (smartphones, tablets, car GPS), and embedded Linux.
+(Windows, Linux), Android (smartphones, tablets, car GPS), and embedded Linux.
 Support to Windows CE (PDAs, PNAs, ...) is discontinued (but still maintained in XCSoar 6.8.x). 
 
 XCSoar is compatible with many peripheral hardware such as varios and

--- a/index.html
+++ b/index.html
@@ -64,9 +64,6 @@ $(function() {
       <li class="list-item-linux">
         <a href="{{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/LINUX/">Linux</a>
       </li>
-      <li class="list-item-mac">
-        <a href="{{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/OSX/">macOS</a>
-      </li>
     </ul>
 
     <hr/>


### PR DESCRIPTION
This pull request is to remove OSX/macOS from the list of supported platforms - OSX hasn't been supported for sometime. The current links to download a version for OSX are broken.
