### PR TITLE
Download for Windows: 64 bits per default

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ $(function() {
         <a href="{{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/PI4/">Raspberry PI 4</a>
       </li>
       <li class="list-item-windows">
-        <a href="{{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/PC/">Windows</a>
+        <a href="{{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/WIN64/">Windows</a>
         <small class="nowrap">(<a href="{{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/PC/">32 bit</a> /
         <a href="{{ site.download_server_url }}/{{ site.xcsoar_stable_version }}/WIN64/">64 bit</a>)</small>
       </li>


### PR DESCRIPTION
Most of current Windows system are 64 bits nowadays (and for a long time).
While clicking on the name "Windows", the 32 bits version was given, which could come as a surprise.