### PR TITLE
fix(theme): Bootstrap button text colour on themed pages

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,7 @@
 {
-  "ignoreFiles": ["lib/**/*"],
+  "ignoreFiles": [
+    "lib/**/*"
+  ],
   "rules": {
     "color-no-invalid-hex": true,
     "declaration-block-no-duplicate-properties": true,

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,4 +1,4 @@
-# Main navbar: order preserved. `type: download_dropdown` renders _includes/nav-download-dropdown.html.
+# Main navbar: order preserved. `type: download_dropdown` / `docs_dropdown` are rendered in nav-main-items.html.
 main:
   - id: home
     home: true
@@ -11,7 +11,8 @@ main:
     href: /news.html
     title: XCSoar news and updates
     menu: news
-  - id: docs
+  - type: docs_dropdown
+    id: docs
     label: Docs
     href: /docs/
     title: XCSoar documentation

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -125,7 +125,9 @@
 
   <main id="main-content">
     {% if page.tagline %}
-    <div id="title" class="home-page-title-row text-center">
-      <h1 class="home-page-title mb-0">{{ page.title }}</h1>
+    <div class="container">
+      <div id="title" class="home-page-title-row text-center">
+        <h1 class="home-page-title mb-0">{{ page.title }}</h1>
+      </div>
     </div>
     {% endif %}

--- a/_includes/nav-main-items.html
+++ b/_includes/nav-main-items.html
@@ -8,6 +8,14 @@
                   <li><a class="dropdown-item{% if nav_url contains '/download/maps/' %} active{% endif %}" href="/download/maps/"{% if nav_url contains '/download/maps/' %} aria-current="page"{% endif %}>Maps</a></li>
                 </ul>
               </li>
+  {% elsif item.type == 'docs_dropdown' %}
+              <li class="nav-item dropdown {{ item.id }}{% if page.menu == item.menu or page.menu == 'hardware' %} current{% endif %}">
+                <a class="nav-link dropdown-toggle{% if page.menu == item.menu or page.menu == 'hardware' %} active{% endif %}" href="{{ item.href }}" id="navbarDocs" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="{{ item.title }}">{{ item.label }}</a>
+                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDocs">
+                  <li><a class="dropdown-item" href="/docs/#manual">Manual</a></li>
+                  <li><a class="dropdown-item{% if nav_url contains '/hardware/' %} active{% endif %}" href="/hardware/"{% if nav_url contains '/hardware/' %} aria-current="page"{% endif %}>Hardware</a></li>
+                </ul>
+              </li>
   {% elsif item.icon %}
               <li class="nav-item {{ item.li_class }}">
                 <a class="nav-link" href="{{ item.href }}" title="{{ item.title }}" target="_blank" rel="noopener noreferrer">

--- a/_posts/2026-03-22-xcsoar-7-dot-44-released.md
+++ b/_posts/2026-03-22-xcsoar-7-dot-44-released.md
@@ -107,7 +107,7 @@ Tobias Bieniek, Tobias Schulte, and Vesko.
 - [LX Navigation](https://www.lxnavigation.com/) Eos/Era variometers
 - [Stratux](https://github.com/stratux/stratux)
 - [Larus](https://www.larus.com/) protocol update to version 0.1.4
-- [OpenVario](https://www.openvario.org/) protocol extended for onboard IMU
+- [OpenVario](https://www.openvario.de/) protocol extended for onboard IMU
   gyroscope/acceleration data
 - [AIR Control Display](https://www.air-avionics.com/comm-and-transponders/)
   driver upgrades, including radio frequency exchange and transponder mode

--- a/css/xcsoar-theme.css
+++ b/css/xcsoar-theme.css
@@ -39,6 +39,24 @@ html[class*="site-theme--"] a:active {
   color: var(--site-a-active);
 }
 
+/*
+ * Global theme link colour (`html … a`) beats Bootstrap’s `.btn-*` (higher specificity),
+ * so solid buttons (e.g. .btn-success) get theme green text on a green background.
+ * Restore Bootstrap’s per-button foreground colours.
+ */
+html[class*="site-theme--"] a.btn:not(.btn-link) {
+  color: var(--bs-btn-color);
+}
+
+html[class*="site-theme--"] a.btn:not(.btn-link):hover,
+html[class*="site-theme--"] a.btn:not(.btn-link):focus-visible {
+  color: var(--bs-btn-hover-color);
+}
+
+html[class*="site-theme--"] a.btn:not(.btn-link):active {
+  color: var(--bs-btn-active-color);
+}
+
 html[class*="site-theme--"] body {
   background: var(--site-body-bg);
 }

--- a/css/xcsoar.css
+++ b/css/xcsoar.css
@@ -125,7 +125,8 @@ blockquote {
 
 .home-page-title-row {
   padding: 0.35rem 0 0.85rem;
-  margin-bottom: 0.15rem;
+  margin-bottom: 1.75rem;
+  border-bottom: 1px dotted #9f9c99;
 }
 
 .home-page-title {
@@ -160,7 +161,7 @@ a#logo.navbar-brand__mark-link {
   flex-shrink: 0;
 }
 .navbar-brand--split .navbar-brand__mark {
-  height: 1.2em;
+  height: 2.4em;
   width: auto;
   flex-shrink: 0;
   vertical-align: middle;

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: "XCSoar documentation — manuals, quick guides, hardware compatibi
 menu: docs
 ---
 
-## Manual
+## Manual {#manual}
 
 Manuals of the stable version {{ site.xcsoar_stable_version }}:
 

--- a/hardware/index.md
+++ b/hardware/index.md
@@ -2,153 +2,138 @@
 layout: simple
 color: green
 title: Hardware
+description: "Platforms, embedded flight hardware, and XCSoar device drivers — Android, Kobo, OpenVario, varios, loggers, and community-tested setups."
 menu: hardware
 ---
 
-XCSoar runs on a wide variety of hardware: desktop computers
-(Windows, Linux), Android (smartphones, tablets, car GPS), and embedded Linux.
-E-ink readers such as the Kobo are very good platforms aswell.
+XCSoar runs on many kinds of hardware: **desktop** (Windows, Linux), **Android** (phones, tablets, and car GPS units), **iOS**, and **embedded Linux**. **E-ink** devices such as Kobo e-readers are popular: the screen is monochrome but stays readable in bright sunlight.
 
-XCSoar is compatible with many peripheral hardware such as varios and
-loggers. Consult [the manual](/docs/) for an extensive
-list.
+XCSoar works with a wide range of **peripherals** (varios, loggers, FLARM, and more). For wiring, protocols, and manuals, see [the documentation](/docs/). The **built-in device drivers** are listed first; further down are **community-reported** Android and Kobo setups.
 
-Many users ask us what hardware they shall buy for running XCSoar.  This
-section describes setups that have been verified to work well.  Please note
-that screen readabillity in direct sunlight is a key feature when choosing a
-device.
+Those examples are **not product endorsements**. XCSoar’s needs change over time—check the current [download](/download/) page for **minimum OS versions** before you buy. For cockpits, **sunlight readability** matters as much as raw specs.
 
-# Android
+## Dedicated embedded hardware {#dedicated-embedded-hardware}
 
-XCSoar has been reported to work on many android products, whether they are
-smartphones, tablets or car GPS.  Note that XCSoar requires Android 5.0 or up.
+Besides consumer phones and tablets, XCSoar is often used with **purpose-built embedded systems**: panel displays, single-board flight computers, and sensor boxes designed for gliders (custom Linux images, embedded Android stacks, or avionics that stream data to XCSoar over serial or Bluetooth).
 
-Android devices known to work well with XCSoar are:
--   Google Pixel 8
--   Google Pixel 8 Pro
--   Galaxy S22 Ultra
--   Google Pixel 6
--   Google Pixel 2
--   Cat S61
+- **[OpenVario](https://www.openvario.de/)** — open flight computer stack; build your own or source an assembled unit via the project site.
+- **[SteFly](https://www.stefly.aero/)** (stefly.aero) — **Larus** gliding sensor hardware and related avionics; works with OpenVario, tablets, or other displays running XCSoar.
+- **[XCNav](https://xcnav.de/)** — Android-based embedded navigation hardware for gliding and ultralight flying.
+- **[XCVario](https://xcvario.com/)** — stand-alone variometer family that exports sensor data to XCSoar (OpenVario, Borgelt, Cambridge-style protocols, Bluetooth/Wi‑Fi/serial).
 
-Android devices known to have issues with XCSoar are:
--   Xiaomi * , due to a [Bluetooth issue](https://github.com/XCSoar/XCSoar/issues/1279)
+## Built-in device drivers {#built-in-device-drivers}
 
+These are the **instrument and simulator drivers** shipped with XCSoar (the labels you pick in *System → Devices*). They are defined in [`src/Device/Register.cpp`](https://github.com/XCSoar/XCSoar/blob/master/src/Device/Register.cpp) in the [XCSoar source tree](https://github.com/XCSoar/XCSoar/tree/master/src/Device/Driver). Use **Generic** for standard NMEA when your hardware does not have a dedicated entry.
 
-## Built-in GPS
+### Variometers and glide computers {#variometers-and-glide-computers}
 
-Most Android devices have built-in GPS. It is good enough for many pilots,
-but there are reasons to connect to other devices: better accuracy,
-MacCready synchronization, task declaration, IGC file download...
+- [BlueFly Vario](https://www.blueflyvario.com/)
+- [Borgelt B50/B800](http://www.borgeltinstruments.com/)
+- [Cambridge CAI302](https://cambridge-aero.com/)
+- [Cambridge CAI GPS-NAV](https://cambridge-aero.com/)
+- [Cambridge L-Nav](https://cambridge-aero.com/)
+- [Digifly Leonardo](https://www.digifly.it/en/)
+- [Flymaster F1](https://www.flymaster.net/)
+- [FlyNet Vario](http://www.asinstrument.ch/) — ASI
+- [Flytec 5030 / Brauniger](https://www.flytec.com/) — Flytec / Bräuniger (Volirium)
+- [ILEC SN10](https://www.ilec.de/)
+- [Larus](https://www.stefly.aero/en/product/larus_glider_sensor/) — [SteFly](https://www.stefly.aero/) (stefly.aero), Larus open sensor project
+- [LöFGREN Variometer](https://www.lofgren-electronics.fr/)
+- [Lx Eos / Era](https://www.lxnavigation.com/) — LX Navigation
+- [LXNAV](https://gliding.lxnav.com/) — variometer and instrument line (S-series, V7, Nano, …)
+- [OpenVario](https://www.openvario.de/)
+- [Thermal Express](https://github.com/XCSoar/XCSoar/tree/master/src/Device/Driver/ThermalExpress) — *protocol-only driver in tree; unknown OEM link—use **Generic** if needed*
+- [Vega](https://cambridge-aero.com/) — Cambridge
+- [Westerboer VW1150](https://www.westerboer.de/)
+- [XC-Tracer Vario](https://www.xctracer.com/en/)
+- [XCVario](https://xcvario.com/)
+- [Zander / SDI](https://github.com/XCSoar/XCSoar/blob/master/src/Device/Driver/Zander.cpp) — Zander instruments with SDI-family data (related to PosiGraph / SDI; see driver notes)
 
-## Bluetooth or IOIO
+### Sensors only {#sensors-only}
 
-Android devices do not have a serial port. There are two ways to
-connect peripherals:
+- [Altair Recording Unit](https://cambridge-aero.com/) — Cambridge
+- [Compass C-Probe](https://www.compass-italy.com/)
+- [EYE sensor-box](https://github.com/XCSoar/XCSoar/tree/master/src/Device/Driver/Eye.cpp) (experimental) — *no stable OEM page; use **Generic** if needed*
+- [EW Logger](https://www.ew.aero/)
+- [EW microRecorder](https://www.ew.aero/)
+- [FLARM](https://flarm.com/)
+- [IMI ERIXX](http://www.imi-gliding.com/)
+- [Levil AHRS](https://levil.com/)
+- PosiGraph Logger — Streamline Digital Instruments (SDI); legacy hardware often documented alongside [LX Navigation](https://www.lxnavigation.com/) / [LXNAV](https://gliding.lxnav.com/) support
+- [Stratux](https://github.com/cyoung/stratux)
+- [Volkslogger](http://www.volkslogger.org/) — Garrecht / Volkslogger
+- [WSI Vaulter](https://github.com/XCSoar/XCSoar/tree/master/src/Device/Driver/Vaulter) — WSI (*upstream site not linked in XCSoar*)
 
-- *Bluetooth*: the wireless solution; you can connect up to 7
-  Bluetooth adapters to your Android
-- *IOIO*: the wired solution; one IOIO adapter has up to 4 serial
-  ports and charges your Android at the same time
+### Transponders and radios
 
-Examples for Bluetooth adapters:
+- [Air Control Display](https://www.air-avionics.com/) — AIR Avionics
+- [ATR833](https://www.funkwerk.com/) — Funkwerk Avionics
+- [KRT2](https://www.tqaviation.com/) — TQ Avionics
+- [XCOM760](http://www.xcom760.com/) — XCOM Avionics
 
-- [SoarTronic's bluetooth adapter](http://www.soartronic.net/products)
-  BT1 (only compatible with FLARM) and BT2
-- [K6-Team K6 BT Mux 2](https://www.k6-team.de/K6-Bt-Mux-2-NMEA-Multiplexer-mit-Bluetooth)
-  a solution that allows baud rate switching
+**Desktop flight simulators** (not panel hardware): [Condor Soaring Simulator](https://www.condorsoaring.com/) (incl. Condor 3). **Generic I/O:** **Generic** (plain NMEA fallback), **NMEA output** (send-only to other equipment).
 
-Examples for IOIO adapters:
+Driver sets and behaviour change by release; see upstream **[NEWS.txt](https://github.com/XCSoar/XCSoar/blob/master/NEWS.txt)**.
 
-- [SoarTronic](http://www.soartronic.net/products) has a Do-It-Yourself kit
-  (without the actual IOIO board)
-- you can [build your own](https://github.com/ytai/ioio/wiki)
+## Android {#android}
 
-# Kobo
+XCSoar runs on many Android devices (phones, tablets, car GPS). **Android 5.0 or newer** is required.
 
-XCSoar supports multiple Kobo e-book readers. These device have an e-ink screen.
-It is black and white, but is perfectly readable in direct sunlight.
+For **phones** used in the cockpit, prefer a **high-nit** display (high peak brightness) so the map stays readable in direct sun on the canopy. Units that are **tested or rated to [MIL-STD-810](https://en.wikipedia.org/wiki/MIL-STD-810)** are often a good fit: that family of tests covers environmental stress, including **pressure altitude** and **temperature** (heat and cold), which matches sailplane use better than typical consumer-only ratings.
 
-The following Kobo models are supported:
+### Devices reported to work well {#android-devices-reported}
 
-- Kobo Mini
-- Kobo Glo
-- Kobo Touch 2.0
-- Kobo Glo HD
+- Google Pixel 8
+- Google Pixel 8 Pro
+- Galaxy S22 Ultra
+- Google Pixel 6
+- Google Pixel 2
+- Cat S61
+
+### Devices with known issues {#android-devices-known-issues}
+
+- **Xiaomi** models (various), due to a [Bluetooth issue](https://github.com/XCSoar/XCSoar/issues/1279)
+
+### Built-in GPS {#android-built-in-gps}
+
+Most Android devices include GPS that is adequate for many flights. External units are still useful for higher accuracy, MacCready sync, task declaration, faster IGC download, and other features.
+
+### Barometer and accelerometer {#android-barometer-accelerometer}
+
+Many Android phones and tablets also ship with an internal **barometer** (pressure sensor) and **accelerometer**. XCSoar can use these for pressure altitude, vario-related behaviour, and motion data where the platform exposes them—**sensor quality and sampling differ widely by device**, so a dedicated vario or external GPS/pressure source is still preferable when you need consistent, high-rate data in turbulence or competitions.
+
+### Bluetooth and IOIO {#android-bluetooth-ioio}
+
+Android has no built-in serial port. Typical options:
+
+- **Bluetooth** — wireless; you can connect multiple Bluetooth adapters (up to seven in many configurations).
+- **IOIO** — wired; one IOIO board can expose several serial ports and charge the device.
+
+**Bluetooth adapters**
+
+- [SoarTronic Bluetooth adapters](http://www.soartronic.net/products) — BT1 (FLARM-oriented) and BT2
+- [K6-Team K6 BT Mux 2](https://www.k6-team.de/K6-Bt-Mux-2-NMEA-Multiplexer-mit-Bluetooth) — NMEA multiplexer with baud rate switching
+
+**IOIO**
+
+- [SoarTronic](http://www.soartronic.net/products) — DIY kit (IOIO board not included)
+- [Build your own](https://github.com/ytai/ioio/wiki) — IOIO project wiki
+
+## Kobo e-readers {#kobo-e-readers}
+
+XCSoar supports several Kobo models. The **e-ink** display is black and white but easy to read in direct sun.
+
+Models recognised in software (by internal hardware ID) are listed in [`src/Kobo/Model.cpp`](https://github.com/XCSoar/XCSoar/blob/master/src/Kobo/Model.cpp) in the XCSoar source. They include:
+
+- Kobo Aura
 - Kobo Aura Edition 2
-
-# Peripherals
-
-## BarOn
-
-The [BarOn](http://aero--tech.ru/en/#BARON) provides atmospheric pressure
-changes to XCSoar through bluetooth.
-
-## BlueFlyVario
-
-The [BlueFlyVario](https://www.blueflyvario.com/) provides atmospheric pressure
-changes (and, optionally, GPS coordinates) to XCSoar.
-
-## Borgelt B800
-
-The [Borgelt B800](http://www.borgeltinstruments.com/?page_id=48)
-is fully supported by XCSoar.
-The [Borgelt Bluetooth Blade](http://www.borgeltinstruments.com/?page_id=156)
-is the dedicated bluetooth adapter.
-
-## Cambridge CAI302
-
-The CAI302 is fully supported by XCSoar, thanks to Cambridge's
-complete protocol documentation. To allow fast IGC file download, it
-is recommended to use the
-[K6-Team Bluetooth adapter](https://www.k6-team.de/K6-Bt-Mux-2-NMEA-Multiplexer-mit-Bluetooth).
-
-## EW microRecorder
-
-The EW microRecorder is fully supported by XCSoar.
-
-## FLARM
-
-Connecting to a [FLARM](https://flarm.com) gives you barometric height and information
-about nearby traffic (FLARM radar). XCSoar can send task declarations
-to an IGC FLARM and can read valid IGC files from it.
-
-[SoarTronic's bluetooth adapter](http://www.soartronic.net/products) is a
-cheap way to connect a FLARM.
-
-## IMI ERIXX
-
-The [IMI ERIXX](http://www.imi-gliding.com/products/erixx-flight-recorder.html)
-is fully supported by XCSoar.
-
-LX navigation
--------------
-
-Era 80 is not working with XCSoar due to a [bug in the device](https://github.com/XCSoar/XCSoar/issues/415).
-
-Era 57 is not supported [at the moment](https://github.com/XCSoar/XCSoar/issues/389).
-
-## LXNAV S7/S8/S100/Nano
-
-LXNAV [S7](https://gliding.lxnav.com/products/s7/), [S8](https://gliding.lxnav.com/products/s8/),
-[S100](https://gliding.lxnav.com/products/s100/) and [Nano](https://gliding.lxnav.com/products/nano/)
-are fully supported by XCSoar, thanks to LXNAV's hardware donations.
-
-LXNAV S8, S100 and Nano have built-in Bluetooth.
-LXNAV sells [a Bluetooth adapter for the S7](https://gliding.lxnav.com/products/s7-s8-s80-bluetooth-module/).
-
-LXNAV Nano [does not support reception of external commands to trigger PEV](https://github.com/XCSoar/XCSoar/issues/1242)
-
-
-## OpenVario
-
-XCSoar is at the heart of the [OpenVario flight computer](https://www.openvario.org/doku.php).
-While OpenVario can be home-built, it can also be assembled for you by a [builder](https://www.openvario.org/doku.php?id=builders:top).
-
-## XCVario
-
-The [XCVario](https://xcvario.com) is an innovative electronic variometer based on both open hard and software.
-
-## XCNav
-
-THe [XCNav](https://xcnav.de/) XCNav edition is a new Android-based multi-platform navigation system for gliding and ultralight flight.
+- Kobo Clara 2E
+- Kobo Clara HD
+- Kobo Glo (incl. refurbished variants covered by the same IDs)
+- Kobo Glo HD
+- Kobo Libra 2
+- Kobo Libra H2O
+- Kobo Mini
+- Kobo Nia
+- Kobo Touch (original)
+- Kobo Touch 2.0

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@ carousel: true
     <p>
       XCSoar is a tactical glide computer for glider pilots.
     </p>
+    <p>Notable features include:</p>
     <ul>
       <li><strong>Moving map</strong> with terrain, topography, and airspace from worldwide databases, including <a href="https://openaip.net/" target="_blank" rel="noopener noreferrer">OpenAIP</a></li>
       <li><strong>Real-time calculations</strong> and navigation</li>
@@ -29,6 +30,9 @@ carousel: true
     </ul>
     <p>
       For cross-country, competitions, or training, XCSoar provides the tools for informed decisions in flight.
+    </p>
+    <p>
+      XCSoar is built with privacy in mind and released as <a href="https://en.wikipedia.org/wiki/Free_software" target="_blank" rel="noopener noreferrer">software libre</a>, so you may run, study, share, and <a href="https://xcsoar.readthedocs.io/en/latest/" target="_blank" rel="noopener noreferrer">improve</a> it on your own terms.
     </p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ carousel: true
       <li><strong>Contest scoring</strong> with automatic <a href="https://weglide.org" target="_blank" rel="noopener noreferrer">WeGlide</a> integration and <a href="https://skylines.aero" target="_blank" rel="noopener noreferrer">SkyLines</a> tracking</li>
       <li><strong>Weather integration</strong> with <a href="https://www.aviationweather.gov/metar" target="_blank" rel="noopener noreferrer">METAR</a>, <a href="https://www.drjack.info/RASP/" target="_blank" rel="noopener noreferrer">RASP</a> forecasts, satellite imagery, and automatic thermals from <a href="https://thermalmap.info" target="_blank" rel="noopener noreferrer">TIM</a></li>
       <li><strong>Airspace warnings</strong> with real-time alerts and filtering</li>
-      <li><strong>Device integration</strong> supporting many manufacturers</li>
+      <li><strong><a href="/hardware/">Device integration</a></strong> supporting many manufacturers</li>
       <li><strong>Flight analysis</strong> with barograms and performance metrics</li>
       <li><strong>Multi-platform</strong> - Linux, Android, iOS, and Windows</li>
     </ul>

--- a/renovate.json
+++ b/renovate.json
@@ -7,41 +7,62 @@
     "schedule:weekly",
     "helpers:pinGitHubActionDigests"
   ],
-  "timezone": "UTC",
-  "labels": ["dependencies"],
+  "labels": [
+    "dependencies"
+  ],
+  "lockFileMaintenance": {
+    "automerge": true,
+    "enabled": true,
+    "schedule": [
+      "before 4am on monday"
+    ]
+  },
+  "packageRules": [
+    {
+      "automerge": true,
+      "description": "Single PR for all GitHub Actions (pin digest + minor/patch)",
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "patch",
+        "minor"
+      ]
+    },
+    {
+      "automerge": true,
+      "description": "Single PR for pre-commit hook revisions",
+      "groupName": "pre-commit hooks",
+      "matchManagers": [
+        "pre-commit"
+      ]
+    },
+    {
+      "automerge": true,
+      "description": "Automerge Ruby patch and minor (not major)",
+      "matchManagers": [
+        "bundler"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    },
+    {
+      "automerge": false,
+      "description": "Require review for major Ruby upgrades",
+      "matchManagers": [
+        "bundler"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
+    }
+  ],
   "platformAutomerge": true,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
-  "packageRules": [
-    {
-      "description": "Single PR for all GitHub Actions (pin digest + minor/patch)",
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "matchUpdateTypes": ["digest", "patch", "minor"],
-      "automerge": true
-    },
-    {
-      "description": "Single PR for pre-commit hook revisions",
-      "matchManagers": ["pre-commit"],
-      "groupName": "pre-commit hooks",
-      "automerge": true
-    },
-    {
-      "description": "Automerge Ruby patch and minor (not major)",
-      "matchManagers": ["bundler"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
-    },
-    {
-      "description": "Require review for major Ruby upgrades",
-      "matchManagers": ["bundler"],
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    }
-  ],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true,
-    "schedule": ["before 4am on monday"]
-  }
+  "timezone": "UTC"
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #167.

The global theme rule `html[class*="site-theme--"] a { color: … }` has higher specificity than Bootstrap’s `.btn-*`, so on green-themed download pages the **Download Maps** button (`.btn-success`) showed green link text on a green background.

## Change

- In `css/xcsoar-theme.css`, restore Bootstrap’s `--bs-btn-color`, `--bs-btn-hover-color`, and `--bs-btn-active-color` for `a.btn` (excluding `.btn-link`).

## Testing

- Open a download page with `color: green` and confirm sidebar buttons (success, warning) have readable label colours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dropdown navigation for documentation in the main navbar.
  * Enhanced homepage with expanded feature descriptions and Device integration link.

* **Documentation**
  * Expanded and restructured hardware documentation with detailed platform information.
  * Updated manual navigation anchors.

* **Style**
  * Improved title section spacing and visual hierarchy with border styling.
  * Enhanced button color consistency across themes.

* **Chores**
  * Updated configuration formatting and automation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->