### PR TITLE
Use Renovate for Bundler; disable Dependabot update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "enabled": true,
   "enabledManagers": [
     "github-actions",
-    "pre-commit"
+    "pre-commit",
+    "bundler"
   ],
   "extends": [
     "config:recommended",
@@ -14,6 +15,13 @@
   "labels": [
     "dependencies"
   ],
+  "lockFileMaintenance": {
+    "automerge": true,
+    "enabled": true,
+    "schedule": [
+      "before 4am on monday"
+    ]
+  },
   "packageRules": [
     {
       "automerge": true,
@@ -34,6 +42,27 @@
       "groupName": "pre-commit hooks",
       "matchManagers": [
         "pre-commit"
+      ]
+    },
+    {
+      "automerge": true,
+      "description": "Automerge Ruby patch and minor (not major)",
+      "matchManagers": [
+        "bundler"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    },
+    {
+      "automerge": false,
+      "description": "Require review for major Ruby upgrades",
+      "matchManagers": [
+        "bundler"
+      ],
+      "matchUpdateTypes": [
+        "major"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- re-enable Bundler manager in `renovate.json`
- restore Renovate lock file maintenance and Bundler update rules (patch/minor automerge, major manual)
- keep dependency update ownership in Renovate

## Operational change already applied
- disabled Dependabot automated security update PRs at repository level via API (`automated-security-fixes: enabled=false`)

## Test plan
- [x] pre-commit hooks pass on `renovate.json`
- [x] verify repository setting reports `automated-security-fixes` disabled